### PR TITLE
spelling fixes

### DIFF
--- a/stethoscope/api/factory.py
+++ b/stethoscope/api/factory.py
@@ -448,7 +448,7 @@ def register_device_api_endpoints(app, config, auth, log_hooks=[]):
     device_plugins.map(_add_route, app, auth, 'devices', 'serial', log_hooks=log_hooks)
 
     # 'merged' endpoints which merge device data across all second-stage device plugins
-    # (without the intial ownership-attribution stage) for lookup by mac, email, serial
+    # (without the initial ownership-attribution stage) for lookup by mac, email, serial
     register_merged_device_endpoints(app, config, auth, device_plugins, apply_practices,
         log_hooks=log_hooks)
 


### PR DESCRIPTION
patch contains some spelling fixes ( just in comments ) as found by a bot ( https://github.com/ka7/misspell_fixer ). Any upcoming License changes (e.g. GPL2 to GPL3+) are hereby granted.