### PR TITLE
Fix link to ReadTheDocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ higher.
 
 ## Next Steps
 
-Our full documentation is available at [https://stethoscope.readthedocs.org]().
+Our full documentation is available at [https://stethoscope.readthedocs.org].
 
 
 ## LICENSE


### PR DESCRIPTION
The current code generates a link to: https://github.com/Netflix/stethoscope/blob/master

This should fix it.