### PR TITLE
Allow registering of notification components

### DIFF
--- a/stethoscope/ui/src/Notification.js
+++ b/stethoscope/ui/src/Notification.js
@@ -1,11 +1,7 @@
 import React, { Component } from 'react'
 import './Notification.css'
-import SimpleNotification from './notifications/Simple'
 import Loader from './Loader'
-
-const notificationComponents = [
-  SimpleNotification
-]
+import NotificationHandlers from './notifications/NotificationHandlers'
 
 class Notification extends Component {
 
@@ -17,14 +13,6 @@ class Notification extends Component {
     }
     this.dismiss = this.dismiss.bind(this)
     this.statusChange = this.statusChange.bind(this)
-    this.notificationComponents = (this.props && this.props.notificationComponents) || notificationComponents
-  }
-
-  getNotificationComponent (data) {
-    for (let i = 0; i < this.notificationComponents.length; i++) {
-      const c = this.notificationComponents[i]
-      if (c.handles(data)) return c
-    }
   }
 
   dismiss () {
@@ -39,9 +27,9 @@ class Notification extends Component {
   render () {
     if (this.state.dismissed) return null
     // get the proper notification Component for this alert
-    const notificationComponent = this.getNotificationComponent(this.props.data)
+    const notificationComponent = NotificationHandlers.getComponentForData(this.props.data)
     if (!notificationComponent) {
-      console.log('No notification component found for notification', this.props.data, 'searched', this.notificationComponents)
+      console.log('No notification component found for notification', this.props.data)
       return null
     }
     const innerNotification = React.createElement(notificationComponent, { data: this.props.data, onDismiss: this.dismiss, onStatusChange: this.statusChange })

--- a/stethoscope/ui/src/index.js
+++ b/stethoscope/ui/src/index.js
@@ -12,6 +12,11 @@ import Devices from './Devices'
 import Accounts from './Accounts'
 import Faq from './Faq'
 
+import NotificationHandlers from './notifications/NotificationHandlers'
+import SimpleNotification from './notifications/Simple'
+
+NotificationHandlers.register(SimpleNotification)
+
 ReactDOM.render(
   <Router history={hashHistory}>
     <Route path='/' component={App}>

--- a/stethoscope/ui/src/notifications/NotificationHandlers.js
+++ b/stethoscope/ui/src/notifications/NotificationHandlers.js
@@ -1,0 +1,23 @@
+if (typeof global.stethoscopeNotificationHandlers === 'undefined') {
+  global.stethoscopeNotificationHandlers = []
+}
+
+const components = global.stethoscopeNotificationHandlers
+
+function register(component) {
+  components.push(component)
+}
+
+function all() {
+  return components
+}
+
+function getComponentForData (data) {
+  const components = all()
+  for (let i = 0; i < components.length; i++) {
+    const c = components[i]
+    if (c.handles(data)) return c
+  }
+}
+
+module.exports = { register, all, getComponentForData }

--- a/stethoscope/ui/src/notifications/NotificationHandlers.js
+++ b/stethoscope/ui/src/notifications/NotificationHandlers.js
@@ -4,11 +4,11 @@ if (typeof global.stethoscopeNotificationHandlers === 'undefined') {
 
 const components = global.stethoscopeNotificationHandlers
 
-function register(component) {
+function register (component) {
   components.push(component)
 }
 
-function all() {
+function all () {
   return components
 }
 


### PR DESCRIPTION
…instead of hardcoding the list of implementations.

The global in NotificationHandler.js shouldn't be necessary, but with certain Webpack configurations, the file can be loaded multiple times, which prevents it from being a single list of components across imports.

With this setup, it's possible to have additional code (outside of this project, or in a fork) add new notification implementations and register them independently.