### PR TITLE
Add Python 3.4 to Travis CI test matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - 2.7
+  - 3.4
   - 3.5
   - 3.6
 addons:


### PR DESCRIPTION
Python 3.4.2 is the default on Debian Jessie, so I've added 3.4 to the test matrix. 