### PR TITLE
Add unknown sources

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -175,6 +175,7 @@ setup_params = dict(
       'remotelogin = stethoscope.plugins.practices:KeyExistencePractice',
       'jailed = stethoscope.plugins.practices:KeyExistencePractice',
       'screenlock = stethoscope.plugins.practices:KeyExistencePractice',
+      'unknownsources = stethoscope.plugins.practices:KeyExistencePractice',
       'uptodate = stethoscope.plugins.practices:UptodatePractice',
       # installed software
       'carbonblack = stethoscope.plugins.practices:InstalledSoftwarePractice',

--- a/stethoscope/api/defaults.py
+++ b/stethoscope/api/defaults.py
@@ -170,4 +170,16 @@ PRACTICES = {
     'PLATFORM_REQUIRED': True,
     'NA_PLATFORMS': MOBILE_PLATFORMS,
   },
+
+  'unknownsources': {
+    'KEY': 'unknownsources',
+    'DISPLAY_TITLE': 'Unknown Sources',
+    'DESCRIPTION': (
+      "Apps from unknown sources are more likely to contain malware than apps "
+      "downloaded from the Play Store. Keeping this setting disabled prevents "
+      "the installation of these apps."
+    ),
+    'PLATFORM_REQUIRED': True,
+    'NA_PLATFORMS': ['iOS'] + NONMOBILE_PLATFORMS,
+  },
 }

--- a/stethoscope/plugins/sources/google/base.py
+++ b/stethoscope/plugins/sources/google/base.py
@@ -168,6 +168,11 @@ class GoogleDataSourceBase(object):
     if encrypted is not None:
       data['practices']['encryption'] = encrypted
 
+    data['practices']['unknownsources'] = {
+      'last_updated': data['last_sync'],
+      'value': not raw['unknownSourcesStatus'],
+    }
+
     # TODO: check 'devicePasswordStatus'? (what does that represent?)
 
     # copy all relevant identifiers

--- a/tests/test_google.py
+++ b/tests/test_google.py
@@ -37,8 +37,16 @@ def mock_datasource():
 def test_process_device_ios(raw_device, mock_datasource):
   device = mock_datasource._process_mobile_device(raw_device)
   pprint.pprint(device)
+
+  last_updated = arrow.get('2016-03-24T01:42:02.702000+00:00')
+
   assert device['practices']['jailed'] == {
-    'last_updated': arrow.get('2016-03-24T01:42:02.702000+00:00'),
+    'last_updated': last_updated,
+  }
+
+  assert device['practices']['unknownsources'] == {
+    'value': False,
+    'last_updated': last_updated,
   }
 
   assert device['source'] == 'google'
@@ -54,14 +62,22 @@ def test_process_device_ios(raw_device, mock_datasource):
 def test_process_device_android(raw_device, mock_datasource):
   device = mock_datasource._process_mobile_device(raw_device)
   pprint.pprint(device)
+
+  last_updated = arrow.get('2016-02-23T21:49:14.719000+00:00')
+
   assert device['practices']['jailed'] == {
     'value': True,
-    'last_updated': arrow.get('2016-02-23T21:49:14.719000+00:00'),
+    'last_updated': last_updated,
   }
 
   assert device['practices']['encryption'] == {
     'value': True,
-    'last_updated': arrow.get('2016-02-23T21:49:14.719000+00:00'),
+    'last_updated': last_updated,
+  }
+
+  assert device['practices']['unknownsources'] == {
+    'value': False,
+    'last_updated': last_updated,
   }
 
   assert device['source'] == 'google'

--- a/tests/test_google.py
+++ b/tests/test_google.py
@@ -45,7 +45,7 @@ def test_process_device_ios(raw_device, mock_datasource):
   }
 
   assert device['practices']['unknownsources'] == {
-    'value': False,
+    'value': True,
     'last_updated': last_updated,
   }
 
@@ -76,7 +76,7 @@ def test_process_device_android(raw_device, mock_datasource):
   }
 
   assert device['practices']['unknownsources'] == {
-    'value': False,
+    'value': True,
     'last_updated': last_updated,
   }
 


### PR DESCRIPTION
Adds the 'unknownsources' practice, which reflects the setting on Android devices which allows installation of apps from sources other than the Google Play store.