### PR TITLE
Move linting into tox.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ cache:
 before_install:
   - nvm install 6.9.5
 install:
-  - ./.travis/install.sh
+  - pip install tox-travis
+  - if [[ "$TEST_SUITE" == "js" ]]; then make install-node-requirements; fi
 script:
-  - make test-$TEST_SUITE
+  - if [[ "$TEST_SUITE" == "js" ]]; then make test-js; else tox; fi

--- a/Makefile
+++ b/Makefile
@@ -78,9 +78,7 @@ dev-token:
 
 lint-py:
 	@echo "--> Linting Python files."
-# settings in setup.cfg
-	pep8 instance config stethoscope tests
-	isort --check-only --recursive --diff instance config stethoscope tests
+	tox -e lint
 
 lint-js:
 	@echo "--> Linting JavaScript files."

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,8 @@ max_line_length = 100
 
 [isort]
 line_length = 100
+known_first_party = stethoscope
+default_section = THIRDPARTY
 known_third_party = six.moves
 indent = '  '
 lines_after_imports = 2

--- a/setup.py
+++ b/setup.py
@@ -124,8 +124,8 @@ setup_params = dict(
   extras_require=extras_require,
   install_requires=install_requires,
   dependency_links=[
-    'git+https://github.com/duosecurity/duo_client_python.git@1cc71f80927b02e75773094c9dd77af1fc8e4064.zip#egg=duo_client-3.0', # noqa
-    'git+https://github.com/wrapp/txwebretry.git@df5014019cf3a5d501bc755b9ce46509c1b31351#egg=txwebretry-0.1.1', # noqa
+    'git+https://github.com/duosecurity/duo_client_python.git@1cc71f80927b02e75773094c9dd77af1fc8e4064.zip#egg=duo_client-3.0',  # noqa
+    'git+https://github.com/wrapp/txwebretry.git@df5014019cf3a5d501bc755b9ce46509c1b31351#egg=txwebretry-0.1.1',  # noqa
   ],
   entry_points={
     'console_scripts': [

--- a/tests/test_google.py
+++ b/tests/test_google.py
@@ -2,8 +2,8 @@
 
 from __future__ import absolute_import, print_function, unicode_literals
 
-import json
 import copy
+import json
 import pprint
 
 import arrow

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,8 @@ skip_install = true
 deps =
   pep8
   isort
+  bandit
 commands =
   pep8 instance config stethoscope tests setup.py
   isort --check-only --recursive --diff instance config stethoscope tests setup.py
+  bandit -r instance config stethoscope

--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,23 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27,py34,py35,py36
+envlist =
+  py27,
+  py34,
+  py35,
+  py36,
+  lint
 
 [testenv]
 install_command = pip install --process-dependency-links {opts} {packages}
 commands = py.test
 deps = -rrequirements.txt
+
+[testenv:lint]
+skip_install = true
+deps =
+  pep8
+  isort
+commands =
+  pep8 instance config stethoscope tests setup.py
+  isort --check-only --recursive --diff instance config stethoscope tests setup.py

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,13 @@ envlist =
   py36,
   lint
 
+[travis]
+python =
+  2.7: py27, lint
+  3.4: py34
+  3.5: py35
+  3.6: py36
+
 [testenv]
 install_command = pip install --process-dependency-links {opts} {packages}
 commands = py.test


### PR DESCRIPTION
Avoids developers having to install isort/pep8/bandit/etc. manually.