### PR TITLE
Drop setuptools-scm

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,10 @@ current_version = 0.1.1
 commit = True
 tag = True
 
+[bumpversion:file:setup.py]
+search = version='{current_version}'
+replace = version='{new_version}'
+
 [aliases]
 test = pytest
 

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ if sys.version_info < (2, 7, 9):
 
 setup_params = dict(
   name='Stethoscope',
-  use_scm_version=True,
+  version='0.1.1',
   author='Andrew M. White',
   author_email='andreww@netflix.com',
   license='Apache License, Version 2.0',
@@ -112,7 +112,6 @@ setup_params = dict(
   include_package_data=True,
   setup_requires=[
     'setuptools-git',  # >=0.3
-    'setuptools-scm',
     'pytest-runner',
   ],
   tests_require=[


### PR DESCRIPTION
Attempting to use `setuptools-scm` for versioning has caused a few issues on build systems as well as with the Docker builds (see https://github.com/Netflix/stethoscope/issues/69#issuecomment-329775938). I don't think it's worth the hassle of maintaining workarounds everywhere, so I'm falling back to static versioning. 