### PR TITLE
Accept 'Verified' as 'validated' for ChromeOS device bootMode.

### DIFF
--- a/stethoscope/plugins/sources/google/base.py
+++ b/stethoscope/plugins/sources/google/base.py
@@ -103,7 +103,7 @@ class GoogleDataSourceBase(object):
     value = get_nonempty_value(raw, 'bootMode')
     return None if value is None else {
       'last_updated': last_updated,
-      'value': (value.lower() == 'validated'),
+      'value': (value.lower() in ('validated', 'verified')),
     }
 
   def _check_encrypted(self, raw, last_updated):


### PR DESCRIPTION
Google's API appears to have started returning `Verified` in place of `validated` as the `bootMode` some ChromeOS devices. I reported this via Google's API docs "report a problem" mechanism last week. Having received no response yet, I'm going to go ahead and assume these are semantically equivalent until I hear otherwise.