### PR TITLE
Check for valid PLUGINS configuration.

### DIFF
--- a/stethoscope/api/factory.py
+++ b/stethoscope/api/factory.py
@@ -678,6 +678,9 @@ def create_app():
 
   config['LOGBOOK'].push_application()
 
+  if "PLUGINS" not in config or len(config["PLUGINS"]) < 1:
+    logger.warn("Missing or invalid PLUGINS configuration!")
+
   app = klein.Klein()
   auth = stethoscope.auth.KleinAuthProvider(config)
   csrf = stethoscope.csrf.CSRFProtection(config)


### PR DESCRIPTION
Fixes #75.

Added a simple check to see if the PLUGINS dict exists and that it has at least one entry.

It was unclear whether I should do a more stringent check of the configured plugins against what is supported in setup.cfg.  Please let me know if I should pursue this route instead.