### PR TITLE
Adding css fix for unclickable disclosure arrows in Chrome

### DIFF
--- a/stethoscope/ui/src/Accessible.js
+++ b/stethoscope/ui/src/Accessible.js
@@ -88,7 +88,7 @@ Accessible.propTypes = {
     'button', 'checkbox', 'dialog', 'gridcell', 'link', 'log', 'marquee',
     'menuitem', 'menuitemcheckbox', 'menuitemradio', 'option', 'progressbar',
     'radio', 'scrollbar', 'slider', 'spinbutton', 'status', 'tab', 'tabpanel',
-    'textbox', 'timer', 'tooltip', 'treeitem', 'switch'
+    'textbox', 'timer', 'tooltip', 'treeitem', 'switch', 'alert'
   ]).isRequired,
   action: PropTypes.func
 }

--- a/stethoscope/ui/src/Device.css
+++ b/stethoscope/ui/src/Device.css
@@ -62,6 +62,7 @@ ul.mac-addresses {
   -ms-transform: rotate(-90deg); /* IE 9 */
   -webkit-transform: rotate(-90deg); /* Chrome, Safari, Opera */
   transform: rotate(90deg);
+  backface-visibility: hidden;
 }
 .toggleLink, .device-info-toggle:hover {
   text-decoration: none;

--- a/stethoscope/ui/src/Devices.css
+++ b/stethoscope/ui/src/Devices.css
@@ -7,6 +7,7 @@ a.toggleLink.closed {
   -ms-transform: rotate(-90deg); /* IE 9 */
   -webkit-transform: rotate(-90deg); /* Chrome, Safari, Opera */
   transform: rotate(90deg);
+  backface-visibility: hidden;
 }
 
 @media only screen and (min-width: 600px)  {


### PR DESCRIPTION
Rotated disclosure arrows were not clickable in Chrome.