### PR TITLE
Add env var to allow skipping of link check in docs env.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -56,9 +56,11 @@ deps =
 commands = flake8 --config=./setup.cfg instance config stethoscope tests setup.py
 
 [testenv:docs]
+passenv = SKIP_LINKCHECK
 deps =
   sphinx
+whitelist_externals = bash
 commands =
   sphinx-build {posargs:-E} -b html docs docs/_build/html
   sphinx-build {posargs:-E} -b doctest docs docs/_build/html
-  sphinx-build -b linkcheck docs docs/_build/html
+  bash -c 'test -n "{env:SKIP_LINKCHECK:}" || sphinx-build -b linkcheck docs docs/_build/html'


### PR DESCRIPTION
This commit forces `tox` to check an environment variable (`SKIP_LINKCHECK`) which, when set, will skip the link-checking portion of the docs check. The variable can be set within Travis CI to prevent spurious test failures when a linked site is down temporarily.